### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ It is generated with [Stainless](https://www.stainless.com/).
 npm install finbud-data
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/glaksmono-finbud-data-mcp).
+
 ## Usage
 
 The full API of this library can be found in [api.md](api.md).


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/glaksmono-finbud-data-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added hosted deployment section to README, detailing availability on Frontier AI with MCP endpoint reference for users exploring deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->